### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,11 @@ kubectl: $(KUBECTL)
 
 .PHONY: help
 help:
-	@awk -F":+ |##" '/^[^\.][0-9a-zA-Z\._\-\%]+:+.+##.+$$/ { printf "\033[36m%-26s\033[0m %s\n", $$1, $$3 }' $(MAKEFILE_LIST) \
+	@awk -F':+ |##' '/^[^\.][0-9a-zA-Z\._\-%]+:+.+##.+$$/ { printf "\033[36m%-26s\033[0m %s\n", $$1, $$3 }' $(MAKEFILE_LIST) \
 	| sort
 
 define MAKE_TARGETS
-  awk -F:+ '/^[^\.%\t\_][0-9a-zA-Z\._\-\%]*:+.*$$/ { printf "%s\n", $$1 }' $(MAKEFILE_LIST)
+  awk -F':+' '/^[^\.%\t\_][0-9a-zA-Z\._\-\%]*:+.*$$/ { printf "%s\n", $$1 }' $(MAKEFILE_LIST)
 endef
 define BASH_AUTOCOMPLETE
   complete -W \"$$($(MAKE_TARGETS) | sort | uniq)\" make gmake m

--- a/s01/e06/Makefile
+++ b/s01/e06/Makefile
@@ -41,6 +41,8 @@ k9s: | $(K9S) $(KUBECONFIG) ## Interact with our K8S cluster via a terminal UI
 	$(K9S) --all-namespaces
 
 define ENV
+export GCP_PROJECT="$(GCP_PROJECT)"
+export GCP_REGION="$(GCP_REGION)"
 export XDG_CONFIG_HOME="$(XDG_CONFIG_HOME)"
 export KUBECONFIG="$(KUBECONFIG)"
 export CLOUDSDK_CONFIG="$(CLOUDSDK_CONFIG)"


### PR DESCRIPTION
GNU Awk 5.1.0 complains about the `\%` sequence because `%` is not a metacharacter.